### PR TITLE
Handle pdf loading client-side error

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 
@@ -9,7 +9,12 @@ export const metadata: Metadata = {
   description: "A comprehensive, industrial-standard PDF editor similar to PDFEscape. Edit, annotate, fill forms, sign documents, and more.",
   keywords: "PDF editor, PDF viewer, edit PDF, annotate PDF, fill PDF forms, sign PDF, PDFEscape alternative",
   authors: [{ name: "PDF Editor Team" }],
-  viewport: "width=device-width, initial-scale=1, maximum-scale=1",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
   themeColor: "#3B82F6",
 };
 

--- a/components/PDFEditor.tsx
+++ b/components/PDFEditor.tsx
@@ -6,7 +6,7 @@ import { PDFManager } from '@/lib/pdf/pdf-manager';
 import PDFViewer from '@/components/pdf/PDFViewer';
 import Toolbar from '@/components/pdf/Toolbar';
 import Sidebar from '@/components/pdf/Sidebar';
-import { cn } from '@/lib/utils';
+import { cn } from '@/lib/utils/index';
 import { 
   APP_NAME,
   DEFAULT_ZOOM,
@@ -14,7 +14,7 @@ import {
   MAX_ZOOM,
   KEYBOARD_SHORTCUTS,
   FEATURE_FLAGS
-} from '@/lib/constants';
+} from '@/lib/constants/index';
 import {
   FiMenu,
   FiX,

--- a/components/pdf/FormBuilder.tsx
+++ b/components/pdf/FormBuilder.tsx
@@ -254,7 +254,7 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { useEditorStore } from '@/store/editor-store';
-import { cn } from '@/lib/utils';
+import { cn } from '@/lib/utils/index';
 import { v4 as uuidv4 } from 'uuid';
 import { toast } from 'react-hot-toast';
 import { HexColorPicker } from 'react-colorful';

--- a/components/pdf/ImageEditor.tsx
+++ b/components/pdf/ImageEditor.tsx
@@ -411,7 +411,7 @@ import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { useEditorStore } from '@/store/editor-store';
-import { cn } from '@/lib/utils';
+import { cn } from '@/lib/utils/index';
 import { v4 as uuidv4 } from 'uuid';
 import { toast } from 'react-hot-toast';
 import { HexColorPicker } from 'react-colorful';

--- a/components/pdf/PDFViewer.tsx
+++ b/components/pdf/PDFViewer.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { Document, Page, pdfjs } from 'react-pdf';
 import { useEditorStore } from '@/store/editor-store';
 import { PDFPage, ViewMode, Annotation, TextElement, ImageElement, DrawingElement, FormField } from '@/types';
-import { cn, debounce, throttle } from '@/lib/utils';
+import { cn, debounce, throttle } from '@/lib/utils/index';
 import { 
   ZOOM_PRESETS,
   MIN_ZOOM,
@@ -13,7 +13,7 @@ import {
   RULER_HEIGHT,
   GUIDE_COLOR,
   DEFAULT_GRID_SIZE
-} from '@/lib/constants';
+} from '@/lib/constants/index';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useResizeDetector } from 'react-resize-detector';
 import { VariableSizeList as List } from 'react-window';

--- a/components/pdf/Sidebar.tsx
+++ b/components/pdf/Sidebar.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { useEditorStore } from '@/store/editor-store';
 import { PDFPage, TextElement, ImageElement, DrawingElement, Annotation, FormField } from '@/types';
-import { cn, formatFileSize, generateId } from '@/lib/utils';
+import { cn, formatFileSize, generateId } from '@/lib/utils/index';
 import { Button } from '@/components/ui/button';
 import {
   FiChevronDown,

--- a/components/pdf/Toolbar.tsx
+++ b/components/pdf/Toolbar.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useEditorStore } from '@/store/editor-store';
 import { Tool, ToolCategory } from '@/types';
-import { cn } from '@/lib/utils';
+import { cn } from '@/lib/utils/index';
 import { Button } from '@/components/ui/button';
 import {
   DEFAULT_COLOR,
@@ -22,7 +22,7 @@ import {
   FORM_FIELD_TYPES,
   SIGNATURE_TYPES,
   WATERMARK_POSITIONS
-} from '@/lib/constants';
+} from '@/lib/constants/index';
 import {
   FiMousePointer,
   FiType,
@@ -78,7 +78,7 @@ import {
   FiCrop,
   FiSliders,
   FiPenTool,
-  FiHighlighter,
+  FiEdit2,
   FiMessageSquare,
   FiBookmark,
   FiTag,
@@ -163,8 +163,7 @@ import {
   FiUmbrella,
   FiCoffee,
   FiFeather,
-  FiPenTool as FiPen,
-  FiEdit2
+  FiPenTool as FiPen
 } from 'react-icons/fi';
 import {
   HiOutlineDocumentText,
@@ -572,7 +571,7 @@ const TOOLS: Record<string, Tool> = {
   highlight: {
     id: 'highlight',
     name: 'Highlight',
-    icon: 'FiHighlighter',
+    icon: 'FiEdit2',
     category: 'annotation',
     shortcut: 'H',
     isActive: false,
@@ -1117,7 +1116,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       FiList,
       FiCalendar,
       FiDroplet,
-      FiHighlighter,
+      FiEdit2,
       FiMessageSquare,
       FiUnderline,
       FiUpload,

--- a/lib/pdf/pdf-manager.ts
+++ b/lib/pdf/pdf-manager.ts
@@ -16,14 +16,14 @@ import {
   PDFPermissions,
   WatermarkPosition
 } from '@/types';
-import { generateId, generateTimestamp } from '@/lib/utils';
+import { generateId, generateTimestamp } from '@/lib/utils/index';
 import { 
   DEFAULT_PAGE_WIDTH, 
   DEFAULT_PAGE_HEIGHT,
   PAPER_SIZES,
   DEFAULT_WATERMARK_OPACITY,
   DEFAULT_WATERMARK_ROTATION
-} from '@/lib/constants';
+} from '@/lib/constants/index';
 
 // Configure PDF.js worker
 if (typeof window !== 'undefined') {

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -8,7 +8,7 @@ import {
   LOCAL_STORAGE_PREFIX,
   SESSION_STORAGE_PREFIX,
   CACHE_DURATION
-} from '@/lib/constants';
+} from '@/lib/constants/index';
 
 // Class name utility
 export function cn(...inputs: ClassValue[]) {

--- a/store/editor-store.ts
+++ b/store/editor-store.ts
@@ -23,14 +23,14 @@ import {
   ActionType
 } from '@/types';
 import { pdfManager } from '@/lib/pdf/pdf-manager';
-import { generateId } from '@/lib/utils';
+import { generateId } from '@/lib/utils/index';
 import {
   DEFAULT_ZOOM,
   MAX_HISTORY_SIZE,
   DEFAULT_TOOL,
   DEFAULT_GRID_SIZE,
   DEFAULT_SNAP_DISTANCE
-} from '@/lib/constants';
+} from '@/lib/constants/index';
 
 interface EditorStore extends EditorState {
   // Document


### PR DESCRIPTION
Resolves client-side application error by fixing module import paths, replacing a non-existent icon, removing a duplicate import, and updating Next.js metadata.

The application failed to load due to incorrect module import paths (e.g., missing `/index` suffix for `constants` and `utils`), a non-existent `FiHighlighter` icon from `react-icons/fi`, a duplicate `FiEdit2` import causing a module parse error, and an outdated Next.js metadata configuration for `viewport` and `themeColor`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6312d90-9f9d-4df0-a362-90f88a937c33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6312d90-9f9d-4df0-a362-90f88a937c33">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

