### PR TITLE
Fix undefined RiRulerLine reference

### DIFF
--- a/components/pdf/Toolbar.tsx
+++ b/components/pdf/Toolbar.tsx
@@ -347,7 +347,8 @@ import {
   RiShareBoxLine,
   RiShareForwardLine,
   RiSendPlaneLine,
-  RiSendPlane2Line
+  RiSendPlane2Line,
+  RiRulerLine
 } from 'react-icons/ri';
 import { motion, AnimatePresence } from 'framer-motion';
 import { HexColorPicker } from 'react-colorful';


### PR DESCRIPTION
Add `RiRulerLine` import to `Toolbar.tsx` to resolve `ReferenceError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d649f6e-3fb5-44d8-9e5e-4da8f12e1e75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d649f6e-3fb5-44d8-9e5e-4da8f12e1e75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

