### PR TITLE
Debug slice not a function errors

### DIFF
--- a/components/PDFEditor.tsx
+++ b/components/PDFEditor.tsx
@@ -868,7 +868,7 @@ export const PDFEditor: React.FC<PDFEditorProps> = ({
   const toggleSidebar = useCallback((side: 'left' | 'right') => {
     setLayout(prev => ({
       ...prev,
-      [`sidebar${side.charAt(0).toUpperCase() + side.slice(1)}`]: !prev[`sidebar${side.charAt(0).toUpperCase() + side.slice(1)}`]
+      [`sidebar${side.charAt(0)?.toUpperCase() + side.slice(1)}`]: !prev[`sidebar${side.charAt(0)?.toUpperCase() + side.slice(1)}`]
     }));
   }, []);
 
@@ -1329,7 +1329,7 @@ export const PDFEditor: React.FC<PDFEditorProps> = ({
                       alt={user.name}
                     />
                     <Avatar.Fallback className="w-full h-full rounded-full bg-gray-300 dark:bg-gray-700 flex items-center justify-center text-xs font-medium">
-                      {user.name.charAt(0).toUpperCase()}
+                      {user.name?.charAt(0)?.toUpperCase() || 'U'}
                     </Avatar.Fallback>
                   </Avatar.Root>
                   <span className="text-sm font-medium">{user.name}</span>

--- a/components/pdf/PDFViewer.tsx
+++ b/components/pdf/PDFViewer.tsx
@@ -564,14 +564,15 @@ export const PDFViewer: React.FC<PDFViewerProps> = ({
 
   // Get drawing bounds
   const getDrawingBounds = (drawing: DrawingElement) => {
-    const xs = drawing.points.map(p => p.x);
-    const ys = drawing.points.map(p => p.y);
+    const points = drawing.points || [];
+    const xs = points.map(p => p.x);
+    const ys = points.map(p => p.y);
     
     return {
-      minX: Math.min(...xs),
-      maxX: Math.max(...xs),
-      minY: Math.min(...ys),
-      maxY: Math.max(...ys),
+      minX: xs.length > 0 ? Math.min(...xs) : 0,
+      maxX: xs.length > 0 ? Math.max(...xs) : 0,
+      minY: ys.length > 0 ? Math.min(...ys) : 0,
+      maxY: ys.length > 0 ? Math.max(...ys) : 0,
     };
   };
 
@@ -756,7 +757,7 @@ export const PDFViewer: React.FC<PDFViewerProps> = ({
           >
             {drawing.type === 'pen' || drawing.type === 'pencil' ? (
               <path
-                d={`M ${drawing.points.map(p => `${p.x * zoom},${p.y * zoom}`).join(' L ')}`}
+                d={`M ${(drawing.points || []).map(p => `${p.x * zoom},${p.y * zoom}`).join(' L ')}`}
                 stroke={drawing.strokeColor}
                 strokeWidth={drawing.strokeWidth * zoom}
                 fill="none"

--- a/components/pdf/Sidebar.tsx
+++ b/components/pdf/Sidebar.tsx
@@ -484,9 +484,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
   // Get history items
   const historyItems = useMemo(() => {
-    return history.slice(0, historyLimit).map((item, index) => ({
+    const historyArray = history?.past || [];
+    return historyArray.slice(0, historyLimit).map((item, index) => ({
       id: `history-${index}`,
-      action: item.action || 'Unknown Action',
+      action: item.type || 'Unknown Action',
       timestamp: item.timestamp || new Date(),
       description: item.description || '',
       canUndo: index < historyIndex,

--- a/components/pdf/Sidebar.tsx
+++ b/components/pdf/Sidebar.tsx
@@ -334,7 +334,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
       allLayers.push({
         id: text.id,
         type: 'text',
-        name: text.content.substring(0, 20) || 'Text Layer',
+        name: text.content?.substring(0, 20) || 'Text Layer',
         visible: text.visible !== false,
         locked: text.locked || false,
         selected: selectedElements.includes(text.id),
@@ -420,7 +420,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
       return Object.entries(grouped).map(([type, layers]) => ({
         id: `group-${type}`,
         type: type as any,
-        name: `${type.charAt(0).toUpperCase() + type.slice(1)} Layers`,
+        name: `${type.charAt(0)?.toUpperCase() + type.slice(1)} Layers`,
         visible: true,
         locked: false,
         selected: false,


### PR DESCRIPTION
Fixes `h.slice is not a function` error by correctly accessing `history.past` and `item.type` in the Sidebar component.

The `history` object from the store is not an array but an object containing `past`, `present`, and `future` arrays. The previous code attempted to call `.slice()` directly on the `history` object, leading to a TypeError. Additionally, the `EditorAction` interface uses `type` instead of `action` for the action name.

---
<a href="https://cursor.com/background-agent?bcId=bc-1cb64504-60c5-4469-9673-742e93f9cc48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1cb64504-60c5-4469-9673-742e93f9cc48">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

