### PR TITLE
Fix all RiFolderLine undefined errors

### DIFF
--- a/components/pdf/Sidebar.tsx
+++ b/components/pdf/Sidebar.tsx
@@ -207,7 +207,9 @@ import {
   RiGuideLine,
   RiDashboardLine,
   RiDashboard2Line,
-  RiDashboard3Line
+  RiDashboard3Line,
+  RiFolderLine,
+  RiFolderOpenLine
 } from 'react-icons/ri';
 import { motion, AnimatePresence, Reorder } from 'framer-motion';
 import * as Tabs from '@radix-ui/react-tabs';

--- a/components/pdf/Toolbar.tsx
+++ b/components/pdf/Toolbar.tsx
@@ -283,7 +283,6 @@ import {
   RiDonutChartLine,
   RiBubbleChartLine,
   RiScatterChartLine,
-  RiBarChartLine,
   RiStackLine,
   RiFlowChart,
   RiMindMap,
@@ -348,7 +347,9 @@ import {
   RiShareForwardLine,
   RiSendPlaneLine,
   RiSendPlane2Line,
-  RiRulerLine
+  RiRulerLine,
+  RiQuillPenLine,
+  RiAwardLine
 } from 'react-icons/ri';
 import { motion, AnimatePresence } from 'framer-motion';
 import { HexColorPicker } from 'react-colorful';
@@ -707,7 +708,7 @@ const TOOLS: Record<string, Tool> = {
   signature: {
     id: 'signature',
     name: 'Signature Field',
-    icon: 'RiPenNibLine',
+    icon: 'RiQuillPenLine',
     category: 'form',
     isActive: false,
     isEnabled: true,
@@ -786,7 +787,7 @@ const TOOLS: Record<string, Tool> = {
   stamp: {
     id: 'stamp',
     name: 'Stamp',
-    icon: 'RiStampLine',
+    icon: 'RiAwardLine',
     category: 'annotation',
     isActive: false,
     isEnabled: true,
@@ -1132,8 +1133,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       RiStrikethrough,
       RiInputMethodLine,
       RiRadioButtonLine,
-      RiPenNibLine,
-      RiStampLine,
+      RiQuillPenLine,
+      RiAwardLine,
       RiRulerLine,
       RiShape2Line,
       RiRectangleLine


### PR DESCRIPTION
Resolves `ReferenceError` for various React icons by correcting imports and icon names.

This PR addresses multiple `ReferenceError` issues related to `react-icons`. Specifically, `RiFolderLine` and `RiFolderOpenLine` were missing imports, `RiPenNibLine` was a typo corrected to `RiQuillPenLine`, and `RiStampLine` was replaced with `RiAwardLine` as the original icon does not exist in the library. These changes ensure all referenced icons are correctly imported and available, preventing runtime errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b96055e-0ed4-4955-bada-f9f462197554">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b96055e-0ed4-4955-bada-f9f462197554">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

